### PR TITLE
Post excerpts

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -5,6 +5,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>DTI | {{ page.title }}</title>
+  {% feed_meta %}
   <link href="/favicon.ico" rel="shortcut icon" type="image/x-icon">
   <link rel="stylesheet" href="{{ '/assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}">
   <!-- Global site tag (gtag.js) - Google Analytics -->

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -17,4 +17,6 @@ layout: default
   {%- endif -%}
 </div>
 
+<h1>{{ page.title }}</h1>
+
 {{content}}

--- a/_posts/2023-03-28-launch.md
+++ b/_posts/2023-03-28-launch.md
@@ -2,9 +2,9 @@
 title:  Data Transfer Initiative Launch
 tags: admin
 author: Chris Riley
-post-excerpt: "Since its founding in 2018, I’ve watched DTP with interest and enthusiasm [...] I’m pleased to announce the creation of the Data Transfer Initiative (DTI), a new non-profit organization that will house DTP and support the work that DTP started, with DTP remaining an open source project as part of DTI."
+excerpt: "Since its founding in 2018, I’ve watched DTP with interest and enthusiasm [...] I’m pleased to announce the creation of the Data Transfer Initiative (DTI), a new non-profit organization that will house DTP and support the work that DTP started, with DTP remaining an open source project as part of DTI."
 ---
-# Data portability fosters innovation and empowers individuals to choose
+**Data portability fosters innovation and empowers individuals to choose**
 
 Throughout my career - from the U.S. Department of State’s internet freedom portfolio to my time as Director of Public Policy at Mozilla - I have worked to advance these values. In this email, I’m excited to share that I am continuing this work as the inaugural Executive Director of the Data Transfer Initiative, a new phase of the Data Transfer Project.
 

--- a/_posts/2023-06-06-complex-problem-space.md
+++ b/_posts/2023-06-06-complex-problem-space.md
@@ -2,10 +2,8 @@
 title: The complex problem space of data portability
 tags: policy
 author: Chris Riley
-post-excerpt: "Articulating the landscape of portability-related problems as classic data portability, protocol interoperability, bulk data transfers, and continuous and realtime portability."
+excerpt: Articulating the landscape of portability-related problems as classic data portability, protocol interoperability, bulk data transfers, and continuous and realtime portability.
 ---
-
-# The complex problem space of data portability
 
 This week, I was invited by my friend [Chinmayi Sharma](https://www.linkedin.com/in/chinmayi-sharma-61b054142?miniProfileUrn=urn%3Ali%3Afs_miniProfile%3AACoAACKI03cBtYVeRlTjMhS7KdB-GfZkK-GTW7U) to speak to her class at UT Austin (virtually - another instance where I'm glad for the ways we've all collectively embraced remote engagement!). Her students are studying decentralization and how protocols and interoperability factor in - a timely space that has seen a ton of new ideas in recent years. I was of course eager to talk about the Data Transfer Initiative and our relevant work, but to do so properly in an educational setting requires quite a lot of context and, well, education. A lot of what I talked about falls into a category of "data portability fundamentals" that isn't yet widely known, so I'm writing up a version of that here - enjoy!
 

--- a/_posts/2023-06-13-communications-information.md
+++ b/_posts/2023-06-13-communications-information.md
@@ -2,10 +2,8 @@
 title: Communications, information, tools, and pathways
 tags: communications
 author: Chris Riley
-post-excerpt: "Thoughts on how to communicate DTI's work effectively, and how the multiplicity of channels landscape parallels data portability."
+excerpt: Thoughts on how to communicate DTI's work effectively, and how the multiplicity of channels landscape parallels data portability.
 ---
-
-# Communications, information, tools, and pathways
 
 One of the unique things about running an organization is universal responsibility. I’ve been in many jobs where I feel like I’m spinning plates on poles, running back and forth between the wobblers, just trying to keep things up and running. In the past, though, there were entire categories of tasks that were “not my problem”, plates that I knew someone else would take responsibility for. Here, ultimately, it’s all on me. And that makes for quite a lot of variability in my days! Let’s look at what’s open on one of my web browser windows right now: I have my DTI email inbox, of course, and my calendar. (I keep my personal email, Twitter/Mastodon/Bluesky, and my todo list open in a different window.) I’m reading an IEEE article about privacy-preserving data exchange agreements. I have a Google Doc open where I’m compiling notes and ideas for a potential future data transfer product. The other four tabs reflect the active project that prompted me to write this piece: two for LinkedIn, one for micro.blog, and one for a tool called MarsEdit, on which I’m currently writing. Because in addition to managing DTI’s substantive product and policy work, legal work, and accounting (with the help of consultants and a growing team, thankfully), I drive DTI's communications work, and that is the topic of today’s piece.
 

--- a/_posts/2023-07-01-measure-the-value.md
+++ b/_posts/2023-07-01-measure-the-value.md
@@ -2,10 +2,8 @@
 title:  It's hard to measure the value of data (transfers).
 tags: metrics
 author: Chris Riley
-post-excerpt: "Data’s fundamental characteristics, including its non-rivalrous nature and its ability to capture key learnings about the past and present – and even, as we see clearly through today’s explosion of large language models, predict the future – allow for an incredible range of valuable use cases, including through the combination of data across sources and across users. But some of the most valuable data is personal data, in which people have privacy rights and (in many countries) robust legal protections. "
+excerpt: Data’s fundamental characteristics, including its non-rivalrous nature and its ability to capture key learnings about the past and present – and even, as we see clearly through today’s explosion of large language models, predict the future – allow for an incredible range of valuable use cases, including through the combination of data across sources and across users. But some of the most valuable data is personal data, in which people have privacy rights and (in many countries) robust legal protections.
 ---
-# It's hard to measure the value of data (transfers).
-
 
 Data’s fundamental characteristics, including its non-rivalrous nature and its ability to capture key learnings about the past and present – and even, as we see clearly through today’s explosion of large language models, predict the future – allow for an incredible range of valuable use cases, including through the combination of data across sources and across users. But some of the most valuable data is personal data, in which people have privacy rights and (in many countries) robust legal protections. Protecting user safety while unlocking the full value of user data is not always straightforward; this difficulty limits new experimentation and value creation that can be created through data transfers, as a necessary side effect of actions to limit the harm that such sharing can also produce. At the Data Transfer Initiative, we’re working to unlock some of that value by empowering people to make a choice to transfer their personal data, thus setting them up to be the principal beneficiaries of the subsequent value creation. And a couple of our recent efforts have brought these data value questions to the surface.
 

--- a/_posts/2023-07-12-welcome.md
+++ b/_posts/2023-07-12-welcome.md
@@ -2,23 +2,17 @@
 title:  Data Transfer Initiative Welcomes Expanded Team & Launches Newsletter
 tags: admin
 author: Chris Riley
-post-excerpt: "It is hard for me to believe that it has only been a few short months since the launch of the Data Transfer Initiative. Since I started, I’ve traveled to DC and Brussels, spoken on panels and government workshops, published a policy one-pager and written new articles, met with policymakers, civil society organizations, and industry stakeholders. And I've done it all as DTI’s sole full-time employee."
 ---
-# Data Transfer Initiative Welcomes Expanded Team & Launches Newsletter
 
 It is hard for me to believe that it has only been a few short months since the launch of the Data Transfer Initiative. Since I started, I’ve traveled to DC and Brussels, spoken on panels and government workshops (check out my slides from the European Commission’s “The DMA and data related obligations” workshop [here](https://dtinit.us21.list-manage.com/track/click?u=3ba10a090b97c2dc608fd780e&id=c9878cc7a6&e=54811e5924)), published a [policy one-pager](https://dtinit.us21.list-manage.com/track/click?u=3ba10a090b97c2dc608fd780e&id=34b1d4dcca&e=54811e5924) and written [new articles](https://dtinit.us21.list-manage.com/track/click?u=3ba10a090b97c2dc608fd780e&id=8b1db241df&e=54811e5924) on [data portability](https://dtinit.us21.list-manage.com/track/click?u=3ba10a090b97c2dc608fd780e&id=16db51fc9b&e=54811e5924), and met with policymakers, civil society organizations, and industry stakeholders. And I've done it all as DTI’s sole full-time employee.
-
 
 However, our mission to empower people by enabling effective data transfers is a significant one and it will require the efforts of many. That is why I’m proud to announce we are expanding the DTI team.
 
 > **Delara Derakhshani** has joined DTI as Director of Policy. Ms. Derakhshani brings more than fifteen years of legal and policy expertise in privacy, technology, and telecommunications in the public and private sector serving in roles with Consumer Reports, Meta’s Reality Labs policy team, and the Entertainment Software Association.
 
-
 > **Lisa Dusseault** will join DTI as our Chief Technology Officer in August. Ms. Dusseault previously served as the CTO and Co-Founder of Compaas. Prior to Compaas, Ms. Dusseault served in technical roles at StubHub, Smule, and Microsoft among others, and spent several years as the Applications Area Director at the Internet Engineering Task Force.
 
-
 ## What’s Next
-
 
 Together with our partners and the open-source community contributing to the Data Transfer Project, we have a number of important data portability projects in the pipeline from additional photo-sharing transfers to explorations of brand new verticals. And, showing the value of data transfers beyond everyday products, we are proud to be partnering with AcademyHealth and the Gordon and Betty Moore Foundation to explore ways for individuals to share their data with medical researchers to improve clinical diagnoses.
 

--- a/_posts/2023-08-01-law-isnt-code.md
+++ b/_posts/2023-08-01-law-isnt-code.md
@@ -2,11 +2,7 @@
 title:  Law isn’t code. The vote is just the beginning.
 tags: policy
 author: Chris Riley
-post-excerpt: "In the data portability world, foundational laws like the EU’s General Data Protection Regulation and California’s privacy laws provide users with the right to request their data from businesses, and the Digital Markets Act in Europe imposes additional portability duties on designated gatekeepers. But tech policy doesn’t stop being relevant when laws are adopted; to the contrary, that’s when the real work begins."
 ---
-
-# Law isn’t code. The vote is just the beginning.
-
 
 In the data portability world, foundational laws like the EU’s General Data Protection Regulation and California’s privacy laws provide users with the right to request their data from businesses, and the Digital Markets Act in Europe imposes additional portability duties on designated gatekeepers. But tech policy doesn’t stop being relevant when laws are adopted; to the contrary, that’s when the real work begins.
 

--- a/_posts/2023-08-28-data-is-binary-but.md
+++ b/_posts/2023-08-28-data-is-binary-but.md
@@ -2,15 +2,12 @@
 title:  Data is binary, but that doesn’t make portability simple.
 tags: challenges
 author: Chris Riley
-post-excerpt: "Data sometimes feels like the simplest thing in the world. It’s just a bunch of 1’s and 0’s, right?
-Often we treat all data the same. For portability, however, we cannot."
+excerpt: Data sometimes feels like the simplest thing in the world. It’s just a bunch of 1’s and 0’s, right? Often we treat all data the same. For portability, however, we cannot.
 ---
-# Data is binary, but that doesn’t make portability simple.
 
 Data sometimes feels like the simplest thing in the world. It’s just a bunch of 1’s and 0’s, right?
 Often we treat all data the same, whether we’re looking at the storage capacity of a new smartphone 
 (do we really need 512GB?) or when Dropbox tells us we’re out of storage space yet again.
-
 
 The metaphors we use double down on homogeneity too. How many times have you heard “Data is the new oil”? Or “money”? Fortunately such blunt comparisons have been widely debunked. But ideas are sticky. Like … oil.
 

--- a/_posts/2023-09-01-hello-world.md
+++ b/_posts/2023-09-01-hello-world.md
@@ -2,10 +2,8 @@
 title:  Publishing the newsletter as a blog
 tags: admin
 author: Lisa Dusseault
-post-excerpt: Our newsletter has been going out by email without our own permanent page and link, but here we are with a blog section at dtinit.org now.
+excerpt: Our newsletter has been going out by email without our own permanent page and link, but here we are with a blog section at dtinit.org now.
 ---
-
-# Blog is UP
 
 Our newsletter has been going out by email without having our own permanent page and link here at dtinit.org, but here we are now with a blog section. We'll be continuing to send newsletters out by email, but also posting the contents as blog posts here for convenience of sharing and discovery.  
 

--- a/_posts/2023-09-12-goals-lenses.md
+++ b/_posts/2023-09-12-goals-lenses.md
@@ -2,44 +2,34 @@
 title:  Data portability serves multiple goals
 tags: metrics
 author: Lisa Dusseault
-post-excerpt: "Competition is a compelling narrative to support data portability policy, and with the implementation of Europe’s Digital Markets Act taking headlines, it’s often front of mind. It’s important to remember that competition is not the only lens..."
+excerpt: Competition is a compelling narrative to support data portability policy, and with the implementation of Europe’s Digital Markets Act taking headlines, it’s often front of mind. It’s important to remember that competition is not the only lens...
 ---
-# Data portability serves multiple goals
 
 Competition is a compelling narrative to support data portability policy, and with the implementation of Europe’s Digital Markets Act taking headlines, it’s often front of mind. Open access principles foster competition and have contributed, in part, to massive successes in the telecom industry – including phone number portability and the ability to buy phones from somebody other than your phone provider. It’d be great to see a similarly large impact in innovation and choice where user-generated content on the Internet is concerned, and it’s very much possible. To help make progress, however, it’s important to remember that competition is not the only lens. Articulating goals and metrics for data portability must see beyond win-lose framings.
 
 ## Why competition is compelling
 
-
 The competition case for data portability is fairly straightforward: Attracting users to a new online service is hard, and even when a startup offers substantial benefit and innovation, users may not feel able to switch. New projects often have to compete not just against a large Internet platform company with lots of budget, lots of users, and a critical mass of activity on the platform, but also with data architectures that (whether intentionally or inadvertently!) make it more difficult to extract user data. Exclusionary architectural choices can include, for example, failing to provide sufficient APIs to allow access to user content through third party services or clients - or even more fundamentally, not giving the user any accessible means in practice to download their content for safekeeping (despite obligations in the EU, California, and elsewhere!).
-
 
 It’s the failed-startup kind of missed opportunity that many data portability policymakers can clearly see. They can see the same large companies maintaining large market shares for years. To these policymakers, consolidation risks slowing innovation and reducing pressure to continue adding product value. And portability helps users who want to migrate between services, an effective grease for sticky markets.
 
-
 ## When framing goals and metrics via competition
-
 
 When data portability is viewed through the competition lens alone, the natural policy goals that follow would be along the lines of: 
  * Users can easily take their content and leave a market dominant platform;
  * New entrants to a market, with new features, can attract users to move their content to the new entrant’s platform; and
  * Market entrants are able to gain market share.
 
-
 These are good goals. But metrics derived from them start to really focus on loss scenarios, e.g.:
  * Monthly active user counts of a “take my content elsewhere” service;
  * Count of new user accounts at startup platforms, that were created by migrating them off a market leader; and
  * Market entrants gain X% of market share, and dominant platforms lose X%.
 
-
 These are zero-sum framings. These goals and metrics assume that for a new entrant to win, a market leader must lose. Furthermore, they fail to capture any sense of user agency. What if a service retains its users because it is, in fact, innovating and staying ahead of the competition? Or because its erstwhile competitors are just bad?
-
 
 Any perspective on the history of the Internet will show that innovation is not always a zero-sum game. Many innovative projects add value to their architects, their users, and also the platforms those users started on. Which raises the question: is there a better way to frame data portability goals and metrics?
 
-
 ## Capturing portability’s benefits for user empowerment
-
 
 Here are three examples of outcome scenarios that don’t seem to fit well within a narrow frame of outcome measurement, but nevertheless reflect user empowerment in reality:
  * Users have an “escape hatch” or backup plan even if they never use it. Wanting to be able to move if needs must, is different than moving away forever. When users don’t feel trapped - and when businesses don’t take their users for granted - the incentives and sentiments are better all around.
@@ -48,14 +38,10 @@ Here are three examples of outcome scenarios that don’t seem to fit well withi
 
  * Data portability requirements that are more stringent than data access requirements can foster 3rd-party value-add use cases that mere data access does not. Even when the user’s data access rights are technically preserved via export of photos in a large ZIP, data portability can require additional functionality such as better-preserved metadata and direct transfer between hosts. Those extra features can support 3rd-party features that do not involve removing the user’s content from its original host.
 
-
 ## Choosing empowerment, not zero-sum framings
-
 
 The origins of data portability on the regulatory landscape are in the EU’s General Data Protection Regulation. Users have a right to data portability under the GDPR, and in laws that mirror its provisions in California and elsewhere – not because of the potential for competitive benefits, but because personal data is personal to them. But measuring the effects of this right continues to be challenging.
 
-
 It can be hard to define goals and metrics with more nuance and less black and white situations than “data moved from here to there and… done.” If one of the goals is that users can move data back and forth when appropriate or maintain content on multiple platforms, what kind of metric could show the success of that? How is market share even measured if a user blends use of their content across multiple platforms? These are open, interesting, and important questions.
-
 
 Bottom line, focusing more on user empowerment as a goal when discussing portability policy and architecture, rather than an overly narrow competition-only lens, is more likely to help achieve the best outcomes, not to mention convince others that this work is worth doing.

--- a/_posts/2023-09-26-text-based-social.md
+++ b/_posts/2023-09-26-text-based-social.md
@@ -2,9 +2,7 @@
 title: Building a more portable future for text-based social
 tags: social
 author: Chris Riley
-post-excerpt: "At DTI, we’re starting to dig into portability solutions for something we’ve been calling “text-based social media” – think Mastodon, Threads, Bluesky, and the-service-formerly-known-as-Twitter. In a social space, the problems are both technical and social problems, and the solutions must be as well."
 ---
-# Building a more portable future for text-based social
 
 At DTI, we’re starting to dig into portability solutions for something we’ve been calling “text-based social media” – think Mastodon, Threads, Bluesky, and the-service-formerly-known-as-Twitter. In a social space, the problems are both technical and social problems, and the solutions must be as well.
 

--- a/_posts/2023-10-10-metrics-for-success.md
+++ b/_posts/2023-10-10-metrics-for-success.md
@@ -2,10 +2,8 @@
 title: Metrics for success in data portability work
 tags: social
 author: Chris Riley
-post-excerpt: "How do you measure success? It's more than the KPIs or OKRs. At DTI we're articulating outcomes, capacities, and outputs to tell our story of impact."
+excerpt: How do you measure success? It's more than the KPIs or OKRs. At DTI we're articulating outcomes, capacities, and outputs to tell our story of impact.
 ---
-
-# Metrics for success in data portability work
 
 How do you measure success?
 

--- a/_posts/2023-10-24-global-developments.md
+++ b/_posts/2023-10-24-global-developments.md
@@ -2,10 +2,8 @@
 title: Global developments in data portability law
 tags: policy
 author: Delara Derakhshani
-post-excerpt: "Five years after GDPR, policymakers around the world have a new, or renewed, interest in data portability. DTI is engaging in this growing landscape."
+excerpt: Five years after GDPR, policymakers around the world have a new, or renewed, interest in data portability. DTI is engaging in this growing landscape.
 ---
-
-# Global developments in data portability law
 
 In [an earlier post from DTI](https://dtinit.org/blog/2023/08/01/law-isnt-code), Chris wrote: “tech policy doesn’t stop being relevant when laws are adopted; to the contrary, that’s when the real work begins.” Implicit in what he wrote is that the first step is the law. Today’s post will check in on the law in the context of data portability.
 

--- a/_posts/2023-11-07-framework-trust.md
+++ b/_posts/2023-11-07-framework-trust.md
@@ -2,10 +2,8 @@
 title: A framework for trusted, safe third-party data transfers
 tags: trust
 author: Chris Riley
-post-excerpt: "At DTI, we're looking to build a framework to establish trust between data hosts and recipients, keeping users safe and empowered at the same time."
+excerpt: At DTI, we're looking to build a framework to establish trust between data hosts and recipients, keeping users safe and empowered at the same time.
 ---
-
-# A framework for trusted, safe third-party data transfers
 
 DTI is a small organization tasked with a big mission: building a healthy data portability ecosystem. Most of our work is collaborative in nature – identifying what we can do alongside other organizations, including of course our partners, but also other organizations both large and small, from industry and civil society.
 

--- a/blog/index.md
+++ b/blog/index.md
@@ -23,7 +23,7 @@
       {%- endif -%}
     </div>
     <p>
-      {{ post.post-excerpt }}
+      {{ post.excerpt }}
     </p>
   </article>
 {% endfor %}


### PR DESCRIPTION
* Added the new RSS feed metadata to the document head

2 efficiency changes:

* Moved the blog page heading to the post template so that it doesn't have to be put in twice by the blog author
* Changed the posts to use the default post excerpt functionality, which can still be overridden as needed