### PR TITLE
Use seo tag

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,10 +5,16 @@ permalink: /:categories/:year/:month/:day/:title
 exclude: [".rvmrc", ".rbenv-version", "ReadMe.md", "Rakefile", "changelog.md", "License.md"]
 highlighter: rouge
 
-# Themes are encouraged to use these universal variables
-# so be sure to set them if your theme uses them.
-#
+# Many of the plugins make use of these variables
 title : Data Transfer Initiative
+description: Home page for the Data Transfer Initiative, a nonprofit organization dedicated to promoting data transfers
+logo: /images/DTImeta.jpg
+social:
+  name: Data Transfer Initiative
+  links:
+    - https://techpolicy.social/@DTinitiative
+    - https://www.linkedin.com/company/data-transfer-initiative/
+    - https://github.com/dtinit
 
 # NOTE: If replacing this next line with your own URL, you likely want "https://" not "http://"
 production_url : https://dtinit.github.io/data-transfer-initiative
@@ -25,3 +31,4 @@ collections:
 
 plugins:
   - jekyll-feed
+  - jekyll-seo-tag

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>DTI | {{ page.title }}</title>
+  {% seo %}
   <link href="/favicon.ico" rel="shortcut icon" type="image/x-icon">
   <link rel="stylesheet" href="{{ '/assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}">
   <!-- Global site tag (gtag.js) - Google Analytics -->

--- a/blog/index.md
+++ b/blog/index.md
@@ -1,3 +1,7 @@
+---
+title: Blog
+---
+
 <h1>
   Blog
   <a class="socialIcon" href="/feed.xml">

--- a/blog/index.md
+++ b/blog/index.md
@@ -1,6 +1,9 @@
-<h1>Blog<a class="socialIcon" href="/feed.xml">
-  <img height="24px" src="/images/rss+feed+24px.png" alt="The abstract icon with radiating quarter-rings that means transmission or feed"/>
-</a></h1>
+<h1>
+  Blog
+  <a class="socialIcon" href="/feed.xml">
+    <img height="24px" src="/images/rss+feed+24px.png" alt="RSS Feed"/>
+  </a>
+</h1>
 
 
 {% for post in site.posts %}

--- a/index.md
+++ b/index.md
@@ -2,22 +2,6 @@
 title: Data Transfer Initiative
 ---
 
-<!--Change These -->
-<meta property="og:title" content="Data Transfer Initiative">
-<meta name="description" content="Home page for the Data Transfer Initiative, a nonprofit organization dedicated to promoting data transfers">
-
-<meta property="og:image" content="https://DTinit.org/images/DTImeta.jpg">
-<meta name="twitter:site" content="@DTinitiative">
-<meta property="og:description" content="Home page for the Data Transfer Initiative, a nonprofit organization dedicated to promoting data transfers">
-<meta property="og:site_name" content="dtinit.org">
-<meta name="twitter:image:alt" content="Capital letters D, T, and I with a line underneath, all in blue">
-<meta name="twitter:image" content="https://DTinit.org/images/DTImeta.jpg"> 
-<meta property="twitter:description" content="Home page for the Data Transfer Initiative, a nonprofit organization dedicated to promoting data transfers">
-<!-- Don't change these -->
-<meta property="og:url" content="https://DTinit.org/index.html">
-<meta property="og:type" content="website" />
-<meta name="twitter:card" content="summary_large_image">
-
 {% comment %}We really need an h1 here but should reorganize info first{% endcomment %}
 
 <section class="section" markdown="1" style="margin-top: 40px;">


### PR DESCRIPTION
The SEO plugin is another one that was already included in the `github-pages` gem, and it will produce all the proper meta tags for us for each page.

Also, when the blog `h1` got changed from markdown it was no longer generating a title, so manually added it.

And changed the RSS image to have link text that would be more appropriate for screen readers. Should have caught that sooner. The same thing needs to be done for the social icons, which was my error.